### PR TITLE
Fix compiler selecting the wrong function overload

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/world.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/world.h
@@ -199,7 +199,7 @@ public:
   void addToObject(const std::string& object_id, const Eigen::Isometry3d& pose, const shapes::ShapeConstPtr& shape,
                    const Eigen::Isometry3d& shape_pose)
   {
-    addToObject(object_id, pose, { shape }, { shape_pose });
+    addToObject(object_id, pose, std::vector<shapes::ShapeConstPtr>{ shape }, EigenSTL::vector_Isometry3d{ shape_pose });
   }
 
   /** \brief Add a shape to an object.
@@ -209,7 +209,8 @@ public:
    * shape_pose is defined relative to the object's pose, not to the world frame. */
   void addToObject(const std::string& object_id, const shapes::ShapeConstPtr& shape, const Eigen::Isometry3d& shape_pose)
   {
-    addToObject(object_id, Eigen::Isometry3d::Identity(), { shape }, { shape_pose });
+    addToObject(object_id, Eigen::Isometry3d::Identity(), std::vector<shapes::ShapeConstPtr>{ shape },
+                EigenSTL::vector_Isometry3d{ shape_pose });
   }
 
   /** \brief Update the pose of a shape in an object. Shape equality is


### PR DESCRIPTION
### Description

Using brackets is causing the function to call itself and copy construct the last two parameters rather than calling the vector version

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
